### PR TITLE
source-install-fix

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -30,5 +30,7 @@ alias vvv='tail -f *[^make].log'
 alias mmm='simlog=$(ls | sort -V | tail -n 1); tail -f $simlog'
 alias mmake='make -j8'
 
+alias -- update-galledanza ='. update-galledanza'
+
 alias came='ssh -C gallegati@menrva1.dima.uniroma1.it'
 alias cama='ssh -C agallega@login.marconi.cineca.it'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Self-installing package to automatically set user defined commands &amp; prefere
 
 ## package installation
 
-This package require a minimal installation, meant not to change along time and to be very simple to update. The few steps to setup everything are just the following:
+This package requires a minimal installation, meant not to change along time and to be very simple to update.
+
+The few steps to setup everything are just the following:
 
 ```
 git clone https://github.com/andreagalle/.galledanza.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# galledanza package
+# galledanza
 Self-installing package to automatically set user defined commands &amp; preferences (aliases, etc...)
 
 ![alt text](/doc/MoscowTimes.png) <!-- taken from here: https://www.themoscowtimes.com/2016/12/30/russia-hacker-superpower-a56704 -->
+
+## package installation
+
+This package require a minimal installation, meant not to change along time and to be very simple to update. The few steps to setup everything are just the following:
+
+```
+git clone https://github.com/andreagalle/.galledanza.git
+cd .galledanza
+. install
+```
+
+remember do not `./install` to have it immediately effective. At this point everything is setup, just play around and if you want to update the package you just have to type `update-galledanza` from wherever you are!
 
 ## setting up email alerts
 

--- a/bin/update-galledanza
+++ b/bin/update-galledanza
@@ -10,8 +10,6 @@ git checkout master
 git pull
 
 . $galledanza_dir/.bash_profile 
-. $galledanza_dir/.bashrc
-. $galledanza_dir/.config
 
 echo ""
 echo "...galledanza package updated to `git describe --tags`"


### PR DESCRIPTION
Without sourcing both `install` and `update-galledanza` the env was not set immediately. Now all the changes are effective immediately.

Have a look at:
* <https://superuser.com/questions/176783/what-is-the-difference-between-executing-a-bash-script-vs-sourcing-it>
* <https://stackoverflow.com/questions/16011245/source-files-in-a-bash-script>