### PR TITLE
preventing: cannot execute binary file install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The few steps to setup everything are just the following:
 ```
 git clone https://github.com/andreagalle/.galledanza.git
 cd .galledanza
-. install
+source ./install
 ```
 
 remember do not `./install` to have it immediately effective. At this point everything is setup, just play around and if you want to update the package you just have to type `update-galledanza` from wherever you are!


### PR DESCRIPTION
running `. install` on **galileo** produced the following error:

```
[agallega@r033c01s05 .galledanza]$ . install 
-bash: .: /usr/bin/install: cannot execute binary file
```

because there was already this `install` exe in the `PATH`:

```
-rwxr-xr-x. 1 root root 140K  5 nov  2016 /usr/bin/install
```

I found this "fix" to prevent collisions with similar executable files already in your `PATH`, producing the `cannot execute binary file` error:

* <https://unix.stackexchange.com/questions/152561/why-does-source-give-an-error-cannot-execute-binary-file>